### PR TITLE
Per-metric tags

### DIFF
--- a/appoptics.go
+++ b/appoptics.go
@@ -97,7 +97,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 		measurement := Measurement{}
 		measurement[Period] = self.Interval.Seconds()
 
-		var mergedTags map[string]string
+		mergedTags := map[string]string{}
 		// Copy to prevent mutating Reporter's global tags
 		for tagName, tagValue := range self.Tags {
 			mergedTags[tagName] = tagValue

--- a/appoptics.go
+++ b/appoptics.go
@@ -146,6 +146,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 				for i, p := range self.Percentiles {
 					measurements[i+1] = Measurement{
 						Name:   fmt.Sprintf("%s.%.2f", measurement[Name], p),
+						Tags:   mergedTags,
 						Value:  s.Percentile(p),
 						Period: measurement[Period],
 					}
@@ -159,6 +160,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 			snapshot.Measurements = append(snapshot.Measurements,
 				Measurement{
 					Name:   fmt.Sprintf("%s.%s", name, "1min"),
+					Tags:   mergedTags,
 					Value:  m.Rate1(),
 					Period: int64(self.Interval.Seconds()),
 					Attributes: map[string]interface{}{
@@ -169,6 +171,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 				},
 				Measurement{
 					Name:   fmt.Sprintf("%s.%s", name, "5min"),
+					Tags:   mergedTags,
 					Value:  m.Rate5(),
 					Period: int64(self.Interval.Seconds()),
 					Attributes: map[string]interface{}{
@@ -179,6 +182,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 				},
 				Measurement{
 					Name:   fmt.Sprintf("%s.%s", name, "15min"),
+					Tags:   mergedTags,
 					Value:  m.Rate15(),
 					Period: int64(self.Interval.Seconds()),
 					Attributes: map[string]interface{}{
@@ -197,6 +201,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 				measurements := make([]Measurement, histogramMeasurementCount, histogramMeasurementCount)
 				measurements[0] = Measurement{
 					Name:       appOpticsName,
+					Tags:       mergedTags,
 					Count:      uint64(m.Count()),
 					Sum:        m.Mean() * float64(m.Count()),
 					Max:        float64(m.Max()),
@@ -208,6 +213,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 				for i, p := range self.Percentiles {
 					measurements[i+1] = Measurement{
 						Name:       fmt.Sprintf("%s.timer.%2.0f", name, p*100),
+						Tags:       mergedTags,
 						Value:      m.Percentile(p),
 						Period:     int64(self.Interval.Seconds()),
 						Attributes: self.TimerAttributes,
@@ -217,6 +223,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 				snapshot.Measurements = append(snapshot.Measurements,
 					Measurement{
 						Name:   fmt.Sprintf("%s.%s", name, "rate.1min"),
+						Tags:   mergedTags,
 						Value:  m.Rate1(),
 						Period: int64(self.Interval.Seconds()),
 						Attributes: map[string]interface{}{
@@ -227,6 +234,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 					},
 					Measurement{
 						Name:   fmt.Sprintf("%s.%s", name, "rate.5min"),
+						Tags:   mergedTags,
 						Value:  m.Rate5(),
 						Period: int64(self.Interval.Seconds()),
 						Attributes: map[string]interface{}{
@@ -237,6 +245,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 					},
 					Measurement{
 						Name:   fmt.Sprintf("%s.%s", name, "rate.15min"),
+						Tags:   mergedTags,
 						Value:  m.Rate15(),
 						Period: int64(self.Interval.Seconds()),
 						Attributes: map[string]interface{}{

--- a/client.go
+++ b/client.go
@@ -13,6 +13,15 @@ const OperationsShort = "ops"
 
 type AppOpticsClient struct {
 	Token string
+	MeasurementsURI string
+}
+
+func NewAppOpticsClient(token, measurementsURI string) *AppOpticsClient {
+	if measurementsURI == "" {
+		measurementsURI = defaultMeasurementsURI
+	}
+
+	return &AppOpticsClient{token, measurementsURI}
 }
 
 // property strings
@@ -51,7 +60,7 @@ const (
 	// batch keys
 	Measurements = "measurements"
 
-	MetricsPostUrl = "https://api.appoptics.com/v1/measurements"
+	defaultMeasurementsURI = "https://api.appoptics.com/v1/measurements"
 )
 
 type Measurement map[string]interface{}
@@ -83,7 +92,7 @@ func (self *AppOpticsClient) PostMetrics(batch Batch) (err error) {
 		return
 	}
 
-	if req, err = http.NewRequest("POST", MetricsPostUrl, bytes.NewBuffer(js)); err != nil {
+	if req, err = http.NewRequest("POST", self.MeasurementsURI, bytes.NewBuffer(js)); err != nil {
 		return
 	}
 

--- a/client.go
+++ b/client.go
@@ -55,7 +55,6 @@ const (
 )
 
 type Measurement map[string]interface{}
-type Metric map[string]interface{}
 
 type Batch struct {
 	Measurements []Measurement     `json:"measurements,omitempty"`

--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 
 const Operations = "operations"
 const OperationsShort = "ops"
+const PartialFailureHeader = "x-partial-failure"
 
 type AppOpticsClient struct {
 	Token string
@@ -104,7 +105,7 @@ func (self *AppOpticsClient) PostMetrics(batch Batch) (err error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusAccepted {
+	if resp.StatusCode != http.StatusAccepted || resp.Header.Get(PartialFailureHeader) != "" {
 		var body []byte
 		if body, err = ioutil.ReadAll(resp.Body); err != nil {
 			body = []byte(fmt.Sprintf("(could not fetch response body for error: %s)", err))

--- a/metrics.go
+++ b/metrics.go
@@ -22,7 +22,7 @@ func Metric(name string) *metric {
 }
 
 func (m *metric) Tag(name string, value interface{}) *metric {
-	tagName := sanitizeTagName(fmt.Sprintf("%v", name))
+	tagName := sanitizeTagName(name)
 	tagValue := sanitizeTagValue(fmt.Sprintf("%v", value))
 	m.tags[tagName] = tagValue
 	return m

--- a/metrics.go
+++ b/metrics.go
@@ -35,7 +35,11 @@ func (m *metric) Sample(s metrics.Sample) *metric {
 func (m *metric) String() string {
 	sb := strings.Builder{}
 
-	sb.WriteString(m.name + "#")
+	sb.WriteString(m.name)
+
+	if len(m.tags) > 0 {
+		sb.WriteString("#")
+	}
 
 	// TODO: sort, for consistent ordering
 	for name, value := range m.tags {
@@ -83,6 +87,10 @@ func (m *metric) Gauge64() metrics.GaugeFloat64 {
 func decodeMetricName(encoded string) (string, map[string]string) {
 	split := strings.SplitN(encoded, "#", 2)
 	name := split[0]
+	if len(split) == 1 {
+		return name, map[string]string{}
+	}
+
 	tagPart := split[1]
 	pairs := strings.Split(tagPart, ",")
 

--- a/metrics.go
+++ b/metrics.go
@@ -13,6 +13,7 @@ var tagValueRegex = regexp.MustCompile(`[^-.:_\\/\w\? ]`)
 type metric struct {
 	name string
 	tags map[string]string
+	sample *metrics.Sample
 }
 
 func Metric(name string) *metric {
@@ -23,6 +24,11 @@ func (m *metric) Tag(name string, value interface{}) *metric {
 	tagName := sanitizeTagName(fmt.Sprintf("%v", name))
 	tagValue := sanitizeTagValue(fmt.Sprintf("%v", value))
 	m.tags[tagName] = tagValue
+	return m
+}
+
+func (m *metric) Sample(s metrics.Sample) *metric {
+	m.sample = &s
 	return m
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -17,7 +17,7 @@ type metric struct {
 }
 
 func Metric(name string) *metric {
-	return &metric{name: name}
+	return &metric{name: name, tags: map[string]string{}}
 }
 
 func (m *metric) Tag(name string, value interface{}) *metric {

--- a/metrics.go
+++ b/metrics.go
@@ -19,7 +19,7 @@ func Metric(name string) *metric {
 	return &metric{name: name}
 }
 
-func (m *metric) Tag(name, value string) *metric {
+func (m *metric) Tag(name string, value interface{}) *metric {
 	tagName := sanitizeTagName(fmt.Sprintf("%v", name))
 	tagValue := sanitizeTagValue(fmt.Sprintf("%v", value))
 	m.tags[tagName] = tagValue

--- a/metrics.go
+++ b/metrics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/rcrowley/go-metrics"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -41,9 +42,15 @@ func (m *metric) String() string {
 		sb.WriteString("#")
 	}
 
-	// TODO: sort, for consistent ordering
-	for name, value := range m.tags {
-		sb.WriteString(name + "=" + value + ",")
+	// Sort tag map for consistent ordering in encoded string
+	var keys []string
+	for key := range m.tags {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		sb.WriteString(key + "=" + m.tags[key] + ",")
 	}
 
 	// Hacky way to remove trailing comma

--- a/metrics.go
+++ b/metrics.go
@@ -3,6 +3,7 @@ package appoptics
 import (
 	"fmt"
 	"github.com/rcrowley/go-metrics"
+	"log"
 	"regexp"
 	"sort"
 	"strings"
@@ -24,6 +25,12 @@ func Metric(name string) *metric {
 func (m *metric) Tag(name string, value interface{}) *metric {
 	tagName := sanitizeTagName(name)
 	tagValue := sanitizeTagValue(fmt.Sprintf("%v", value))
+
+	if tagName == "" || tagValue == "" {
+		log.Printf("Empty tag name or value: name=%v value=%v", tagName, tagValue)
+		return m
+	}
+
 	m.tags[tagName] = tagValue
 	return m
 }
@@ -105,6 +112,10 @@ func decodeMetricName(encoded string) (string, map[string]string) {
 	tags := map[string]string{}
 	for _, pair := range pairs {
 		pairList := strings.SplitN(pair, "=", 2)
+		if len(pairList) != 2 {
+			log.Printf("Tag name `%v` is missing its value", pairList[0])
+			continue
+		}
 		tags[pairList[0]] = pairList[1]
 	}
 

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,94 @@
+package appoptics
+
+import (
+	"fmt"
+	"github.com/rcrowley/go-metrics"
+	"regexp"
+	"strings"
+)
+
+var tagNameRegex = regexp.MustCompile(`[^-.:_\w]`)
+var tagValueRegex = regexp.MustCompile(`[^-.:_\\/\w\? ]`)
+
+type metric struct {
+	name string
+	tags map[string]string
+}
+
+func Metric(name string) *metric {
+	return &metric{name: name}
+}
+
+func (m *metric) Tag(name, value string) *metric {
+	tagName := sanitizeTagName(fmt.Sprintf("%v", name))
+	tagValue := sanitizeTagValue(fmt.Sprintf("%v", value))
+	m.tags[tagName] = tagValue
+	return m
+}
+
+func (m *metric) String() string {
+	sb := strings.Builder{}
+
+	sb.WriteString(m.name + "#")
+
+	// TODO: sort, for consistent ordering
+	for name, value := range m.tags {
+		sb.WriteString(name + "=" + value + ",")
+	}
+
+	// Hacky way to remove trailing comma
+	return strings.TrimSuffix(sb.String(), ",")
+}
+
+func (m *metric) Counter() metrics.Counter {
+	return metrics.GetOrRegisterCounter(m.String(), metrics.DefaultRegistry)
+}
+
+func (m *metric) Meter() metrics.Meter {
+	return metrics.GetOrRegisterMeter(m.String(), metrics.DefaultRegistry)
+}
+
+func (m *metric) Timer() metrics.Timer {
+	return metrics.GetOrRegisterTimer(m.String(), metrics.DefaultRegistry)
+}
+
+func (m *metric) Histogram(s metrics.Sample) metrics.Histogram {
+	return metrics.GetOrRegisterHistogram(m.String(), metrics.DefaultRegistry, s)
+}
+
+func (m *metric) Gauge() metrics.Gauge {
+	return metrics.GetOrRegisterGauge(m.String(), metrics.DefaultRegistry)
+}
+
+// decodeMetricName decodes the metricName#a=foo,b=bar format and returns the metric name
+// as a string and the tags as a map
+func decodeMetricName(encoded string) (string, map[string]string) {
+	split := strings.SplitN(encoded, "#", 2)
+	name := split[0]
+	tagPart := split[1]
+	pairs := strings.Split(tagPart, ",")
+
+	tags := map[string]string{}
+	for _, pair := range pairs {
+		pairList := strings.SplitN(pair, "=", 2)
+		tags[pairList[0]] = pairList[1]
+	}
+
+	return name, tags
+}
+
+func sanitizeTagName(value string) string {
+	if len(value) > 64 {
+		value = value[:64]
+	}
+	value = strings.ToLower(value)
+	return tagNameRegex.ReplaceAllString(value, "_")
+}
+
+func sanitizeTagValue(value string) string {
+	if len(value) > 255 {
+		value = value[:252] + "..."
+	}
+	value = strings.ToLower(value)
+	return tagValueRegex.ReplaceAllString(value, "_")
+}

--- a/metrics.go
+++ b/metrics.go
@@ -105,7 +105,7 @@ func decodeMetricName(encoded string) (string, map[string]string) {
 	split := strings.SplitN(encoded, "#", 2)
 	name := split[0]
 	if len(split) == 1 {
-		return name, map[string]string{}
+		return name, nil
 	}
 
 	tagPart := split[1]

--- a/metrics.go
+++ b/metrics.go
@@ -56,12 +56,14 @@ func (m *metric) String() string {
 	}
 	sort.Strings(keys)
 
-	for _, key := range keys {
-		sb.WriteString(key + "=" + m.tags[key] + ",")
+	for i, key := range keys {
+		if i != 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(key + "=" + m.tags[key])
 	}
 
-	// Hacky way to remove trailing comma
-	return strings.TrimSuffix(sb.String(), ",")
+	return sb.String()
 }
 
 func (m *metric) Counter() metrics.Counter {

--- a/metrics.go
+++ b/metrics.go
@@ -52,12 +52,24 @@ func (m *metric) Timer() metrics.Timer {
 	return metrics.GetOrRegisterTimer(m.String(), metrics.DefaultRegistry)
 }
 
-func (m *metric) Histogram(s metrics.Sample) metrics.Histogram {
-	return metrics.GetOrRegisterHistogram(m.String(), metrics.DefaultRegistry, s)
+func (m *metric) Histogram() metrics.Histogram {
+	sample := func(s *metrics.Sample) metrics.Sample {
+		if s == nil {
+			return metrics.NewExpDecaySample(1028, 0.015)
+		} else {
+			return *s
+		}
+	}
+
+	return metrics.GetOrRegister(m.String(), sample(m.sample)).(metrics.Histogram)
 }
 
 func (m *metric) Gauge() metrics.Gauge {
 	return metrics.GetOrRegisterGauge(m.String(), metrics.DefaultRegistry)
+}
+
+func (m *metric) Gauge64() metrics.GaugeFloat64 {
+	return metrics.GetOrRegisterGaugeFloat64(m.String(), metrics.DefaultRegistry)
 }
 
 // decodeMetricName decodes the metricName#a=foo,b=bar format and returns the metric name

--- a/metrics.go
+++ b/metrics.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 )
 
+var metricNameRegex = regexp.MustCompile(`[^-.:_\w]`)
 var tagNameRegex = regexp.MustCompile(`[^-.:_\w]`)
 var tagValueRegex = regexp.MustCompile(`[^-.:_\\/\w\? ]`)
 
@@ -19,7 +20,7 @@ type TaggedMetric struct {
 }
 
 func Metric(name string) *TaggedMetric {
-	return &TaggedMetric{name: name, tags: map[string]string{}}
+	return &TaggedMetric{name: sanitizeMetricName(name), tags: map[string]string{}}
 }
 
 func (t *TaggedMetric) Tag(name string, value interface{}) *TaggedMetric {
@@ -138,4 +139,11 @@ func sanitizeTagValue(value string) string {
 	}
 	value = strings.ToLower(value)
 	return tagValueRegex.ReplaceAllString(value, "_")
+}
+
+func sanitizeMetricName(value string) string {
+	if len(value) > 255 {
+		value = value[:252] + "..."
+	}
+	return metricNameRegex.ReplaceAllString(value, "_")
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -22,6 +22,5 @@ func TestDecodeMetric(t *testing.T) {
 func TestEncodeMetric(t *testing.T) {
 	assert.Equal(t, "myMetric", Metric("myMetric").String())
 	assert.Equal(t, "myMetric#foo=1", Metric("myMetric").Tag("foo", 1).String())
-	assert.Equal(t, "myMetric#foo=1,bar=2", Metric("myMetric").Tag("foo", 1).Tag("bar", 2).String())
-
+	assert.Equal(t, "myMetric#bar=2,foo=1", Metric("myMetric").Tag("foo", 1).Tag("bar", 2).String())
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -24,3 +24,11 @@ func TestEncodeMetric(t *testing.T) {
 	assert.Equal(t, "myMetric#foo=1", Metric("myMetric").Tag("foo", 1).String())
 	assert.Equal(t, "myMetric#bar=2,foo=1", Metric("myMetric").Tag("foo", 1).Tag("bar", 2).String())
 }
+
+func TestTagSanitation(t *testing.T) {
+	metric := Metric("myMetric")
+	assert.Equal(t, "myMetric#foo=1_2", metric.Tag("foo", "1&2").String())
+
+	metric = Metric("myMetric")
+	assert.Equal(t, "myMetric#f_o=1", metric.Tag("f=o", "1").String())
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,27 @@
+package appoptics
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDecodeMetric(t *testing.T) {
+	name, tags := decodeMetricName("myMetric")
+	assert.Equal(t, "myMetric", name)
+	assert.Equal(t, map[string]string{}, tags)
+
+	name, tags = decodeMetricName("myMetric#foo=1")
+	assert.Equal(t, "myMetric", name)
+	assert.Equal(t, map[string]string{"foo": "1"}, tags)
+
+	name, tags = decodeMetricName("myMetric#foo=1,bar=2")
+	assert.Equal(t, "myMetric", name)
+	assert.Equal(t, map[string]string{"foo": "1", "bar": "2"}, tags)
+}
+
+func TestEncodeMetric(t *testing.T) {
+	assert.Equal(t, "myMetric", Metric("myMetric").String())
+	assert.Equal(t, "myMetric#foo=1", Metric("myMetric").Tag("foo", 1).String())
+	assert.Equal(t, "myMetric#foo=1,bar=2", Metric("myMetric").Tag("foo", 1).Tag("bar", 2).String())
+
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -32,3 +32,11 @@ func TestTagSanitation(t *testing.T) {
 	metric = Metric("myMetric")
 	assert.Equal(t, "myMetric#f_o=1", metric.Tag("f=o", "1").String())
 }
+
+func TestMetricSanitation(t *testing.T) {
+	metric := Metric("myMetric#")
+	assert.Equal(t, "myMetric_", metric.String())
+
+	metric = Metric("myMetric#").Tag("foo", "bar")
+	assert.Equal(t, "myMetric_#foo=bar", metric.String())
+}


### PR DESCRIPTION
This implements #1, using the encoding format described: `MyMetricName#tagA=foo,tagB=bar`. The encoded metric+tag name is then decoded before submitting metrics to AppOptics.

This change extends the API following the model of https://github.com/appoptics/metrics-appoptics:

``` golang
appoptics.Metric("myMetric").Tag("tagA", "foo").Tag("tagB", "bar").Meter().Mark()
```

Or, create a histogram with custom sample type:

``` golang
appoptics.Metric("myMetric").Tag("tag", "foo").WithSample(func() metrics.Sample { return metrics.NewUniformSample(1000) }).Histogram().Update(100)
```

This also adds the ability to override the API endpoint used. This makes it possible for AppOptics staff to test this against our staging environment.